### PR TITLE
remove codec dependency; don't support metadata from codec

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cincy
 Title: Cincinnati Neighborhood, Tract, County, and ZIP Code Geographies
-Version: 1.0.3
+Version: 1.1.0
 Authors@R: c(
     person("Cole", "Brokamp", , "cole.brokamp@gmail.com", role = c("aut", "cre")),
     person("Erika", "Rasnick", role = c("aut"))
@@ -21,7 +21,6 @@ Imports:
     sf,
     tibble,
     tidyselect, 
-    codec (>= 0.6.0), 
     purrr
 Suggests: 
     GGally,
@@ -41,6 +40,5 @@ Suggests:
     leaflet.extras
 Remotes:
     yutannihilation/ggsflabel,
-    geomarker-io/codec
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/R/interpolate.R
+++ b/R/interpolate.R
@@ -133,25 +133,6 @@ interpolate <- function(from, to, weights = c("pop", "homes", "area")) {
   out_data <- dplyr::left_join(to_non_extensive, to_extensive, by = to_id)
   out_data <- dplyr::left_join(to, out_data, by = to_id)
 
-  # re-assign metadata, if it exists
-  if ({!is.null(attr(from, "profile"))} && attr(from, "profile") == "tabular-data-resource") {
-    from_tdr <- codec:::make_tdr_from_attr(from)
-    desc <- purrr::pluck(from_tdr)
-    flds <- purrr::pluck(from_tdr, "schema", "fields")
-    purrr::pluck(desc, "schema") <- NULL
-    desc <- purrr::compact(desc)
-
-    out_data <- codec::add_attrs(out_data, !!!desc)
-
-    flds <- purrr::discard(flds, \(.x) .x$name == from_id)
-    for (the_field in names(flds)) {
-      out_data[[the_field]] <-
-        codec::add_attrs(out_data[[the_field]], !!!flds[[the_field]])
-    }
-
-    out_data[[to_id]] <- codec::add_attrs(out_data[[to_id]], name = to_id, type = "string")
-  }
-
   return(out_data)
 }
 

--- a/tests/testthat/test-interpolate.R
+++ b/tests/testthat/test-interpolate.R
@@ -43,24 +43,3 @@ test_that("ids checks", {
   expect_message(
     interpolate(dep_index |> sf::st_transform(3537), cincy::zcta_tigris_2010))
 })
-
-test_that("merging and interpolate keeps metadata", {
-
-  hamilton_landcover_tract <-
-    codec::codec_data("hamilton_landcover") |>
-    dplyr::left_join(cincy::tract_tigris_2010, by = dplyr::join_by(census_tract_id_2010)) |>
-    sf::st_as_sf()
-
-  expect_equal(attr(hamilton_landcover_tract, "profile"), "tabular-data-resource")
-  expect_equal(attr(hamilton_landcover_tract, "homepage"), "https://geomarker.io/hamilton_landcover")
-  expect_equal(attr(hamilton_landcover_tract$pct_green_2019, "title"), "Percent Greenspace 2019")
-  expect_equal(attr(hamilton_landcover_tract$census_tract_id_2010, "title"), "Census Tract Identifier")
-
-  hamilton_landcover_zcta <- interpolate(hamilton_landcover_tract, cincy::zcta_tigris_2010, "pop")
-
-  expect_equal(attr(hamilton_landcover_zcta, "profile"), "tabular-data-resource")
-  expect_equal(attr(hamilton_landcover_zcta, "homepage"), "https://geomarker.io/hamilton_landcover")
-  expect_equal(attr(hamilton_landcover_zcta$pct_green_2019, "title"), "Percent Greenspace 2019")
-  expect_null(attr(hamilton_landcover_zcta$census_tract_id_2010, "title")) # ensure tract id column is gone
-  expect_equal(attr(hamilton_landcover_zcta$zcta_2010, "name"), "zcta_2010")
-})


### PR DESCRIPTION
rather than having cyclical dependencies, this will be handled in the codec package itself;
e.g., by coercing to a tibble, interpolating, then reattaching metadata list to make a fr_tdr object